### PR TITLE
prpc: remove asyncio

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -1,16 +1,9 @@
-import asyncio
-
-from prpc.client import ClientFactory
+from prpc.client import run_client
 
 
-client = ClientFactory().connect('localhost', 12345)
-client.cast('__main__.foo', 'arg1', foo='bar')
-
-
-async def do_call():
+async def foo(client):
     res = await client.call('__main__.foo', 'arg1', foo='bar')
-    print('got res', res)
+    print('got', res)
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(do_call())
+run_client(foo, host='::1', port=12345)

--- a/prpc/protocol/base.py
+++ b/prpc/protocol/base.py
@@ -64,6 +64,7 @@ message_type_map = {
 
 
 class BaseProtocol(metaclass=ABCMeta):
+    message_size = None
 
     @abstractmethod
     def feed(self, data):

--- a/prpc/protocol/msgpack.py
+++ b/prpc/protocol/msgpack.py
@@ -4,6 +4,8 @@ from prpc.protocol.base import BaseProtocol
 
 
 class MsgpackProtocol(BaseProtocol):
+    message_size = 16 * 1024
+
     def __init__(self):
         self.unpacker = msgpack.Unpacker()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 attrs>=16.3.0
 msgpack_ext>=0.1.1
 structlog>=17.2.0
+trio~=0.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,4 +9,4 @@ flake8-import-order>=0.8
 # pytest
 pytest>=3.0.5
 pytest-sugar>=0.8.0
-pytest-asyncio>=0.5.0
+asynctest>=0.10.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,33 +1,36 @@
-from unittest import mock
-from unittest.mock import patch, sentinel
+from asynctest import mock, patch, sentinel
 
 import pytest
 
 from prpc.protocol import base
-from prpc.server import ProtocolServer
+from prpc.server import Server
 
 
 @pytest.fixture
 @patch.multiple(base.BaseProtocol, __abstractmethods__=set())
-def server(transport):
+def protocol():
+    protocol = base.BaseProtocol()
+
+    return protocol
+
+
+@pytest.fixture
+def server(transport, protocol):
     application = mock.Mock()
     application.handle_method.return_value = sentinel.return_value
 
-    protocol = base.BaseProtocol
-    server = ProtocolServer(application, protocol)
-
-    server.connection_made(transport)
+    server = Server(application, lambda: protocol)
 
     return server
 
 
-def test_handle_message_request(buf, server):
+async def test_handle_message_request(buf, server, transport, protocol):
 
-    message = base.Request(
+    transport.message = base.Request(
         method=sentinel.method,
     )
 
-    server.data_received(message)
+    await server.handle_recv(transport, protocol)
 
     server.application.handle_method.assert_called_once_with(
         sentinel.method
@@ -36,17 +39,17 @@ def test_handle_message_request(buf, server):
     assert len(buf) == 1
     assert buf[0].result == sentinel.return_value
     assert buf[0].error is None
-    assert buf[0].id == message.id
+    assert buf[0].id == transport.message.id
     assert isinstance(buf[0], base.Response)
 
 
-def test_handle_message_notification(buf, server):
+async def test_handle_message_notification(buf, server, transport, protocol):
 
-    message = base.Notification(
+    transport.message = base.Notification(
         method=sentinel.method
     )
 
-    server.data_received(message)
+    await server.handle_recv(transport, protocol)
 
     server.application.handle_method.assert_called_once_with(
         sentinel.method


### PR DESCRIPTION
This replaces asyncio with trio. Reasons for doing this:

 * less buffer bloat
 * uncomplicated flow control
 * async all the way up